### PR TITLE
Escape `[` and `]` used in values within produced shell code

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -26,6 +26,9 @@ Modules 5.6.0 (not yet released)
 * Doc: add :ref:`acknowledgments` page in the documentation.
 * Doc: describe :ref:`GOVERNANCE`.
 * Doc: add :ref:`CHARTER`.
+* Escape square brackets (``[]``) used in values within produced shell code as
+  these characters may have special meaning on some shells (like *csh*). (fix
+  issue #565)
 
 .. _Security policy: https://github.com/envmodules/modules/blob/main/SECURITY.md
 

--- a/tcl/util.tcl
+++ b/tcl/util.tcl
@@ -20,11 +20,11 @@
 
 ##########################################################################
 
-proc charEscaped {str {charlist " \\\\\t{}|<>!;#^\$&*?\"'`()"}} {
+proc charEscaped {str {charlist " \\\\\t{}\\\[\\\]|<>!;#^\$&*?\"'`()"}} {
    return [regsub -all "\(\[$charlist\]\)" $str {\\\1}]
 }
 
-proc charUnescaped {str {charlist " \\\\\t{}|<>!;#^\$&*?\"'`()"}} {
+proc charUnescaped {str {charlist " \\\\\t{}\\\[\\\]|<>!;#^\$&*?\"'`()"}} {
    return [regsub -all "\\\\\(\[$charlist\]\)" $str {\1}]
 }
 

--- a/testsuite/config/base-config.exp
+++ b/testsuite/config/base-config.exp
@@ -234,7 +234,7 @@ proc shell_val {test_shell val {re_mode 0}} {
     if {$val ne "(.*)"} {
         switch -- $test_shell {
             {sh} - {bash} - {ksh} - {zsh} - {csh} - {tcsh} - {fish} {
-                set val [regsub -all {([\\"'$|<>{}`*? ()!&;])} $val {\\\1}]
+                set val [regsub -all {([\\"'$|<>{}`*? ()!&;\[\]])} $val {\\\1}]
             }
             {lisp} - {cmake} {
                 set val [regsub -all {(["])} $val {\\\1}]

--- a/testsuite/install.00-init/020-module.exp
+++ b/testsuite/install.00-init/020-module.exp
@@ -47,9 +47,9 @@ if {[find_bin grep] ne "" && [find_bin tr] ne "" && [find_bin awk] ne ""} {
    foreach shell $shell_list {
       if {$shell eq {csh} || $shell eq {tcsh}} {
          # alias evaluation leads to a syntax error if wa_277 is enabled
-         testall_cmd_re "$shell" "module load $testsuite_modpath/alias/3.0\; testsuite; ts2" [expr {$install_wa277 eq {y} ? {} : "Release\nhttp://an.example.web\\?&param=one"}] ".*" [expr {$install_wa277 eq {y} ? 1 : 0}]
+         testall_cmd_re "$shell" "module load $testsuite_modpath/alias/3.0\; testsuite; ts2; ts3" [expr {$install_wa277 eq {y} ? {} : "Release\nhttp://an.example.web\\?&param=one\nselect\\\[type==BAR && osrel==FOO\\\] myapp"}] ".*" [expr {$install_wa277 eq {y} ? 1 : 0}]
       } else {
-         testall_cmd_re "$shell" "module load $testsuite_modpath/alias/3.0\; testsuite; ts2" "Release\nhttp://an.example.web\\?&param=one" ".*" 0
+         testall_cmd_re "$shell" "module load $testsuite_modpath/alias/3.0\; testsuite; ts2; ts3" "Release\nhttp://an.example.web\\?&param=one\nselect\\\[type==BAR && osrel==FOO\\\] myapp" ".*" 0
       }
    }
 } elseif {$verbose} {

--- a/testsuite/install.00-init/024-ml.exp
+++ b/testsuite/install.00-init/024-ml.exp
@@ -50,9 +50,9 @@ if {[find_bin grep] ne "" && [find_bin tr] ne "" && [find_bin awk] ne ""} {
    foreach shell $shell_list {
       if {$shell eq {csh} || $shell eq {tcsh}} {
          # alias evaluation leads to a syntax error if wa_277 is enabled
-         testall_cmd_re "$shell" "ml $testsuite_modpath/alias/3.0\; testsuite; ts2" [expr {$install_wa277 eq {y} ? {} : "Release\nhttp://an.example.web\\?&param=one"}] ".*" [expr {$install_wa277 eq {y} ? 1 : 0}]
+         testall_cmd_re "$shell" "ml $testsuite_modpath/alias/3.0\; testsuite; ts2; ts3" [expr {$install_wa277 eq {y} ? {} : "Release\nhttp://an.example.web\\?&param=one\nselect\\\[type==BAR && osrel==FOO\\\] myapp"}] ".*" [expr {$install_wa277 eq {y} ? 1 : 0}]
       } else {
-         testall_cmd_re "$shell" "ml $testsuite_modpath/alias/3.0\; testsuite; ts2" "Release\nhttp://an.example.web\\?&param=one" ".*" 0
+         testall_cmd_re "$shell" "ml $testsuite_modpath/alias/3.0\; testsuite; ts2; ts3" "Release\nhttp://an.example.web\\?&param=one\nselect\\\[type==BAR && osrel==FOO\\\] myapp" ".*" 0
       }
    }
 } elseif {$verbose} {

--- a/testsuite/modulefiles/alias/3.0
+++ b/testsuite/modulefiles/alias/3.0
@@ -38,3 +38,5 @@ switch -- [module-info shelltype] {
 
 # check '?' and '&' are correctly escaped
 set-alias ts2 {echo "http://an.example.web?&param=one"}
+# check '[' and ']' are correctly escaped
+set-alias ts3 "echo \"select\[type==BAR && osrel==FOO\]\" myapp"

--- a/testsuite/modules.50-cmds/076-alias-sub.exp
+++ b/testsuite/modules.50-cmds/076-alias-sub.exp
@@ -87,6 +87,7 @@ lappend ans [list set __MODULES_LMREFRESH $module]
 lappend ans [list set _LMFILES_ $modulefile]
 lappend ans [list set LOADEDMODULES $module]
 lappend ans [list alias ts2 {echo "http://an.example.web?&param=one"}]
+lappend ans [list alias ts3 {echo "select[type==BAR && osrel==FOO]" myapp}]
 lappend ans [list alias testsuite {echo $(grep "report .Modules " modulecmd.tcl | tr -d \\ | awk '{print $3}')}]
 
 set ans2 [list]
@@ -94,6 +95,7 @@ lappend ans2 [list set __MODULES_LMREFRESH $module]
 lappend ans2 [list set _LMFILES_ $modulefile]
 lappend ans2 [list set LOADEDMODULES $module]
 lappend ans2 [list alias ts2 {echo "http://an.example.web?&param=one"}]
+lappend ans2 [list alias ts3 {echo "select[type==BAR && osrel==FOO]" myapp}]
 lappend ans2 [list alias testsuite {echo `grep "report .Modules " modulecmd.tcl | tr -d \\ | awk '{print $3}'`}]
 
 set ans3 [list]
@@ -101,6 +103,7 @@ lappend ans3 [list set __MODULES_LMREFRESH $module]
 lappend ans3 [list set _LMFILES_ $modulefile]
 lappend ans3 [list set LOADEDMODULES $module]
 lappend ans3 [list alias ts2 {echo "http://an.example.web?&param=one"}]
+lappend ans3 [list alias ts3 {echo "select[type==BAR && osrel==FOO]" myapp}]
 lappend ans3 [list alias testsuite {echo (grep "report .Modules " modulecmd.tcl | tr -d \\ | awk '{print $3}')}]
 
 


### PR DESCRIPTION
Square brackets may have special meaning on some shells (like csh), so they should be escaped.

Fixes #565