### PR TITLE
gh: stop export-ignoring .clusterfuzzlite in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 version.inc.in export-subst
 # no export of git-specific stuff
 .github export-ignore
-.clusterfuzzlite export-ignore
 .gitignore export-ignore
 .gitattributes export-ignore
 init/.gitignore export-ignore
@@ -17,5 +16,10 @@ script/commit-msg export-ignore
 script/pre-commit export-ignore
 .codespellrc export-ignore
 .hunspell.en.dic export-ignore
+# .clusterfuzzlite is intentionally NOT export-ignored: GitHub's archive
+# generation (used by e.g. codeload.github.com) honors export-ignore, and
+# OSSF Scorecard's Fuzzing check reads .clusterfuzzlite/Dockerfile from
+# that same archive, so export-ignoring it hides the fuzzing setup from
+# Scorecard entirely
 # no export of website-specific content
 doc/talk export-ignore

--- a/.hunspell.en.dic
+++ b/.hunspell.en.dic
@@ -1517,3 +1517,5 @@ request's
 uid
 gitignored
 ObjCmd
+codeload
+integrations


### PR DESCRIPTION
## Summary
- The OSSF Scorecard "Fuzzing" check (added in #662) still reported "no fuzzer integrations found" on a fresh `scorecard.yml` run against the exact merge commit that introduced `.clusterfuzzlite/`.
- Root cause: `.gitattributes` had `.clusterfuzzlite export-ignore`, and GitHub's archive generation (`codeload.github.com`) honors `export-ignore`. Downloading that commit's own tarball confirmed `.clusterfuzzlite/` (like `.github/`) is entirely absent from it — so Scorecard's check for `.clusterfuzzlite/Dockerfile` content never had a chance to see the file, regardless of what's actually committed.
- Remove `.clusterfuzzlite` from `export-ignore` and document why, so it doesn't get re-added later without realizing the conflict with Scorecard detection.

## Test plan
- [x] `git archive --worktree-attributes HEAD | tar t` locally confirms `.clusterfuzzlite/*` files are now included (same mechanism GitHub's tarball generation uses), where they were previously absent.
- [ ] After merge, re-check `scorecard.dev`/the `security/code-scanning/7` alert for a non-zero Fuzzing score once the next `scorecard.yml` run picks up this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)