### PR TITLE
gh: pin cflite base image by digest, track it via Dependabot

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder:v1
+FROM gcr.io/oss-fuzz-base/base-builder:v1@sha256:8b4a73d83374b298a0a771eeec9a1d44ceff3416a678b7d7946303389d022aca
 RUN apt-get update && apt-get install -y autoconf tcl8.6-dev
 COPY . $SRC/modules
 WORKDIR $SRC/modules

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/.clusterfuzzlite"
+    schedule:
+      interval: "weekly"

--- a/doc/source/devel/ci.rst
+++ b/doc/source/devel/ci.rst
@@ -222,5 +222,8 @@ Dependency updates
 ``github-actions`` ecosystem (i.e. the ``uses:`` action references in
 :file:`.github/workflows/`) weekly and open pull requests to bump pinned
 versions, keeping the actions used by all of the above workflows current.
+It also checks the ``docker`` ecosystem in :file:`.clusterfuzzlite/`,
+keeping the digest-pinned ``FROM`` line in
+:file:`.clusterfuzzlite/Dockerfile` current.
 
 .. vim:set tabstop=2 shiftwidth=2 expandtab autoindent:


### PR DESCRIPTION
## Summary
- Fixes security/code-scanning/10 (OSSF Scorecard "Pinned-Dependencies"), a direct side effect of #663: once Scorecard could actually see `.clusterfuzzlite/Dockerfile`, it flagged `FROM gcr.io/oss-fuzz-base/base-builder:v1` as an unpinned (mutable-tag) dependency.
- Pin the base image by digest (`sha256:8b4a73d8...`), verified directly against the GCR registry API before use rather than trusting the Scorecard remediation tip blindly.
- Add a `docker` Dependabot ecosystem entry for `.clusterfuzzlite/` so the pinned digest gets bumped automatically as the upstream OSS-Fuzz base image is rebuilt, matching the existing `github-actions` ecosystem entry's role for action SHAs.
- Document the new Dependabot ecosystem in `doc/source/devel/ci.rst`.