### PR TITLE
ts: close remaining Codecov gaps in tcl/, fix 3 dead branches

### DIFF
--- a/.hunspell.en.dic
+++ b/.hunspell.en.dic
@@ -615,6 +615,7 @@ modrc
 modscan
 modshare
 modspec
+moduleUnmetDep
 moduleVersSpec
 modulecache
 modulecmd
@@ -897,12 +898,14 @@ tweakable
 txt
 ubuntu
 umask
+ummod
 un
 unalias
 uname
 uncomplete
 undef
 unhide
+unmetDepHash
 unix
 unixtime
 unixtimestamp
@@ -912,6 +915,7 @@ unlink
 unloadable
 unprefixed
 unsetConf
+unsetModuleDependency
 unsetState
 unsetenv
 unsets

--- a/.hunspell.en.dic
+++ b/.hunspell.en.dic
@@ -607,6 +607,7 @@ modEq
 modEqStatic
 modStartNb
 modVariantCmp
+modarg
 modetype
 modfile
 modquar
@@ -659,6 +660,7 @@ netcdf
 netlib
 newfstatat
 nglfar
+ni
 noLoadIntel
 nocaseatall
 noclobber

--- a/.hunspell.en.dic
+++ b/.hunspell.en.dic
@@ -256,6 +256,9 @@ autoload
 automake
 autopoint
 autoreconf
+autosym
+autosym10
+autosymbol
 autotools
 availabilities
 avx

--- a/.hunspell.en.dic
+++ b/.hunspell.en.dic
@@ -516,6 +516,7 @@ initdir
 initializations
 initlist
 initprepend
+initproc
 initrc
 initrm
 initswitch
@@ -523,6 +524,7 @@ instopt
 intbe
 intelmpi
 interp
+intvallist
 io
 isExtraMatchSearchRequired
 isModuleEvaluated
@@ -903,6 +905,7 @@ unix
 unixtime
 unixtimestamp
 unk
+unkeyed
 unlink
 unloadable
 unprefixed
@@ -925,6 +928,7 @@ userlvl
 usr
 utitilies
 va
+validvallist
 variantifspec
 variantname
 vectorization

--- a/tcl/modfind.tcl.in
+++ b/tcl/modfind.tcl.in
@@ -2490,13 +2490,11 @@ proc unsetModuleDependency {mod} {
    # unset eventual registered unmet dependencies
    if {[info exists ::g_moduleUnmetDep($mod)]} {
       foreach ummod $::g_moduleUnmetDep($mod) {
-         if {[info exists ::g_unmetDepHash($ummod)]} {
-            set idx [lsearch -exact $::g_unmetDepHash($ummod) $mod]
-            set ::g_unmetDepHash($ummod) [lreplace $::g_unmetDepHash($ummod)\
-               $idx $idx+1]
-            if {![llength $::g_unmetDepHash($ummod)]} {
-               unset ::g_unmetDepHash($ummod)
-            }
+         set idx [lsearch -exact $::g_unmetDepHash($ummod) $mod]
+         set ::g_unmetDepHash($ummod) [lreplace $::g_unmetDepHash($ummod)\
+            $idx $idx+1]
+         if {![llength $::g_unmetDepHash($ummod)]} {
+            unset ::g_unmetDepHash($ummod)
          }
       }
       reportDebug "unset unmet requirements for '$mod'"

--- a/tcl/modfind.tcl.in
+++ b/tcl/modfind.tcl.in
@@ -3396,9 +3396,6 @@ proc getModules {dir {mod {}} {fetch_mtime 0} {search {}} {filter {}}} {
 
          # build module symbol list
          lappend versmod_list($versmod) $vers
-      # add global/user rc def to module symbol list in any cases
-      } elseif {!$add_rc_defs && [info exists g_rcVersion($vers)]} {
-         lappend versmod_list($versmod) $vers
       }
    }
 

--- a/tcl/report.tcl.in
+++ b/tcl/report.tcl.in
@@ -1598,9 +1598,6 @@ proc reportModules {search_queries header hsgrkey hstyle show_mtime show_idx\
    if {$json} {
       ##nagelfar ignore Found constant
       upvar 0 clean_list display_list
-      if {![info exists display_list]} {
-         set display_list {}
-      }
    } else {
       set display_list {}
       foreach disp $clean_list {

--- a/testsuite/example/.modulespath.in
+++ b/testsuite/example/.modulespath.in
@@ -16,5 +16,5 @@
 #				# location of version files
 @VERSIONING@@baseprefix@/$MODULE_VERSION/modulefiles	# Module pkg modulefiles (if versioning)
 @NOTVERSIONING@@modulefilesdir@	# Module pkg modulefiles (if no versioning)
-@prefix@/test/modulefiles:@prefix@/test/etc				# General module files
+@prefix@/test/modulefiles:@prefix@/test/etc:@prefix@/test/absent	# General module files, last one unresolved
 #@prefix@/your_contribs			# Edit for your requirements

--- a/testsuite/example/siteconfig.tcl-1
+++ b/testsuite/example/siteconfig.tcl-1
@@ -331,6 +331,17 @@ if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_REDEFONTHEFLYPROCS)]} {
     report [modEq foo fOo equal]
 }
 
+# defineGetEqArrayKeyProc redefinition coverage test
+if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_REDEFGETEQARRAYKEYPROC)]} {
+    array set arr {foo/1.0 {version foo/1.0}}
+    defineGetEqArrayKeyProc 0
+    report [getEqArrayKey arr foo/1.0]
+    defineGetEqArrayKeyProc 1
+    report [getEqArrayKey arr foo/1.0]
+    defineGetEqArrayKeyProc 0
+    report [getEqArrayKey arr foo/1.0]
+}
+
 # specific tests to improve formatErrStackTrace proc coverage
 if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_FORMATERRSTACKTRACE)]} {
     set errmsg {error message

--- a/testsuite/example/siteconfig.tcl-1
+++ b/testsuite/example/siteconfig.tcl-1
@@ -331,15 +331,42 @@ if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_REDEFONTHEFLYPROCS)]} {
     report [modEq foo fOo equal]
 }
 
-# defineGetEqArrayKeyProc redefinition coverage test
+# defineGetEqArrayKeyProc redefinition coverage test: the first two calls
+# use the same implicit_default value in a row to exercise the no-op path
+# where the currently active variant already matches what is being asked
+# for; the following two calls switch value each time, to exercise the
+# rename-the-previous-variant-back path in both directions
 if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_REDEFGETEQARRAYKEYPROC)]} {
     array set arr {foo/1.0 {version foo/1.0}}
+    defineGetEqArrayKeyProc 0
+    report [getEqArrayKey arr foo/1.0]
     defineGetEqArrayKeyProc 0
     report [getEqArrayKey arr foo/1.0]
     defineGetEqArrayKeyProc 1
     report [getEqArrayKey arr foo/1.0]
     defineGetEqArrayKeyProc 0
     report [getEqArrayKey arr foo/1.0]
+}
+
+# getMatchingTagList coverage test: force a duplicate tag entry directly in
+# the global tag structures (setModspecTag itself always dedupes by tag
+# name, so this shape cannot occur through module-tag/module-hide/
+# module-forbid) to exercise the "tag already seen earlier in this same
+# call" skip path, which normal usage never reaches
+if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_DUPTAGROOT)]} {
+    defineModEqProc 0 0
+    set ::g_moduleTagRoot(duptagtest) [list sometag sometag]
+    set ::g_moduleTagRootSpec(duptagtest) [list [list duptagtest/1.0 {}]\
+        [list duptagtest/1.0 {}]]
+    report [getMatchingTagList duptagtest/1.0]
+}
+
+# getAvailListFromVersSpec coverage test: its only caller (the extra-match
+# search dispatch in modscan.tcl) always passes a modarg already registered
+# through parseModuleSpecification, so the unregistered-modarg path is
+# exercised directly here instead
+if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_AVAILLISTUNREG)]} {
+    report [string length [getAvailListFromVersSpec neverregisteredmodarg]]
 }
 
 # specific tests to improve formatErrStackTrace proc coverage

--- a/testsuite/example/siteconfig.tcl-1
+++ b/testsuite/example/siteconfig.tcl-1
@@ -371,6 +371,24 @@ if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_BADVARIANTSHORTCUTDFLVALUE)]} {
     set g_config_defs(variant_shortcut) {MODULES_VARIANT_SHORTCUT {foo} 0 l {} {} initConfVariantShortcut}
 }
 
+# exercise the single-element validvallist "string is" class check path in
+# getConf, not used by any current config option, by superseding an existing
+# lockable option's definition with that shape
+if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_VALIDVALLISTSTRINGIS)]} {
+    set ::g_config_defs(run_quarantine) {MODULES_RUN_QUARANTINE default 0 s\
+        integer}
+    set env(MODULES_RUN_QUARANTINE) 42
+    report [getConf run_quarantine]
+}
+
+# exercise the generic intvallist conversion path in getConf when no initproc
+# is set, not used by any current config option (the only option using
+# intvallist, color, has an initproc superseding this path)
+if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_INTVALLISTCONV)]} {
+    set ::g_config_defs(csh_limit) {{} val2 0 s {val1 val2} {10 20}}
+    report [getConf csh_limit]
+}
+
 # specific tests to improve getModuleDesignation procs coverage
 if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_GETMODULEDESIGNATION)]} {
     # test disabled sgr mode

--- a/testsuite/id
+++ b/testsuite/id
@@ -1,5 +1,5 @@
 #!/bin/sh
 # fake id output
 
-echo "uid=1000(user) gid=1000(user) groups=1000(user),10(wheel),135(mock)"
+echo "uid=1000(user) gid=1000(user) groups=1000(user),10(wheel),135(mock) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023"
 exit 0

--- a/testsuite/modulefiles.4/autosym10/.modulerc
+++ b/testsuite/modulefiles.4/autosym10/.modulerc
@@ -1,0 +1,4 @@
+#%Module
+module-version /2 latest
+module-forbid autosym10/latest
+module-hide --hard autosym10/latest

--- a/testsuite/modulefiles.4/autosym10/1
+++ b/testsuite/modulefiles.4/autosym10/1
@@ -1,0 +1,2 @@
+#%Module
+module-whatis [module-info name]

--- a/testsuite/modulefiles.4/autosym10/2
+++ b/testsuite/modulefiles.4/autosym10/2
@@ -1,0 +1,2 @@
+#%Module
+module-whatis [module-info name]

--- a/testsuite/modulefiles.4/loc_edm1/.version
+++ b/testsuite/modulefiles.4/loc_edm1/.version
@@ -1,0 +1,3 @@
+#%Module
+
+module-version ./1.0.1 default

--- a/testsuite/modulefiles.4/loc_edm1/1.0.1
+++ b/testsuite/modulefiles.4/loc_edm1/1.0.1
@@ -1,0 +1,2 @@
+#%Module
+module-whatis loc_edm1/1.0.1

--- a/testsuite/modulefiles.4/loc_edm1/1.0.2
+++ b/testsuite/modulefiles.4/loc_edm1/1.0.2
@@ -1,0 +1,2 @@
+#%Module
+module-whatis loc_edm1/1.0.2

--- a/testsuite/modulefiles.4/warn/.modulerc
+++ b/testsuite/modulefiles.4/warn/.modulerc
@@ -28,6 +28,9 @@ if {[info exists env(TESTSUITE_WARN)]} {
         rc_bad4 {
            module-warn --message text --unk warn/1
         }
+        rc_bad5 {
+           module-warn --message
+        }
         user1 {
            module-warn --message text --user [module-info username] warn/1
         }

--- a/testsuite/modulefiles.4/warn/1
+++ b/testsuite/modulefiles.4/warn/1
@@ -25,5 +25,8 @@ if {[info exists env(TESTSUITE_WARN)]} {
         mf_bad4 {
             module-warn --message text --unk warn/1
         }
+        mf_bad5 {
+            module-warn --message
+        }
     }
 }

--- a/testsuite/modules.00-init/120-siteconfig.exp
+++ b/testsuite/modules.00-init/120-siteconfig.exp
@@ -589,6 +589,16 @@ lappend ans $vers_reportre
 testouterr_cmd_re sh -V OK [join $ans \n]
 unsetenv_var TESTSUITE_ENABLE_SITECONFIG_REDEFONTHEFLYPROCS
 
+# test redefinition of defineGetEqArrayKeyProc, called twice in a row with a
+# different implicit_default value each time, to demonstrate it renaming the
+# previously active variant back before renaming the new one in
+setenv_var TESTSUITE_ENABLE_SITECONFIG_REDEFGETEQARRAYKEYPROC 1
+set ans [list]
+lappend ans foo/1.0 foo/1.0 foo/1.0
+lappend ans $vers_reportre
+testouterr_cmd_re sh -V OK [join $ans \n]
+unsetenv_var TESTSUITE_ENABLE_SITECONFIG_REDEFGETEQARRAYKEYPROC
+
 # specific tests to improve formatErrStackTrace proc coverage
 setenv_var TESTSUITE_ENABLE_SITECONFIG_FORMATERRSTACKTRACE 1
 set ans [list]

--- a/testsuite/modules.00-init/120-siteconfig.exp
+++ b/testsuite/modules.00-init/120-siteconfig.exp
@@ -589,15 +589,36 @@ lappend ans $vers_reportre
 testouterr_cmd_re sh -V OK [join $ans \n]
 unsetenv_var TESTSUITE_ENABLE_SITECONFIG_REDEFONTHEFLYPROCS
 
-# test redefinition of defineGetEqArrayKeyProc, called twice in a row with a
-# different implicit_default value each time, to demonstrate it renaming the
-# previously active variant back before renaming the new one in
+# test redefinition of defineGetEqArrayKeyProc: the same implicit_default
+# value called twice in a row is a no-op (the currently active variant
+# already matches), then a different value each time demonstrates renaming
+# the previously active variant back before renaming the new one in
 setenv_var TESTSUITE_ENABLE_SITECONFIG_REDEFGETEQARRAYKEYPROC 1
 set ans [list]
-lappend ans foo/1.0 foo/1.0 foo/1.0
+lappend ans foo/1.0 foo/1.0 foo/1.0 foo/1.0
 lappend ans $vers_reportre
 testouterr_cmd_re sh -V OK [join $ans \n]
 unsetenv_var TESTSUITE_ENABLE_SITECONFIG_REDEFGETEQARRAYKEYPROC
+
+# test getMatchingTagList's "tag already seen earlier in this same call"
+# skip path, forced through a duplicate tag entry directly in the global tag
+# structures since normal module-tag usage always dedupes by tag name
+setenv_var TESTSUITE_ENABLE_SITECONFIG_DUPTAGROOT 1
+set ans [list]
+lappend ans sometag
+lappend ans $vers_reportre
+testouterr_cmd_re sh -V OK [join $ans \n]
+unsetenv_var TESTSUITE_ENABLE_SITECONFIG_DUPTAGROOT
+
+# test getAvailListFromVersSpec's unregistered-modarg path, not reachable
+# through its only real caller since every modarg reaching it there is
+# already registered through parseModuleSpecification
+setenv_var TESTSUITE_ENABLE_SITECONFIG_AVAILLISTUNREG 1
+set ans [list]
+lappend ans 0
+lappend ans $vers_reportre
+testouterr_cmd_re sh -V OK [join $ans \n]
+unsetenv_var TESTSUITE_ENABLE_SITECONFIG_AVAILLISTUNREG
 
 # test the single-element validvallist "string is" class check path in
 # getConf, not exercised by any current config option's own shape

--- a/testsuite/modules.00-init/120-siteconfig.exp
+++ b/testsuite/modules.00-init/120-siteconfig.exp
@@ -599,6 +599,24 @@ lappend ans $vers_reportre
 testouterr_cmd_re sh -V OK [join $ans \n]
 unsetenv_var TESTSUITE_ENABLE_SITECONFIG_REDEFGETEQARRAYKEYPROC
 
+# test the single-element validvallist "string is" class check path in
+# getConf, not exercised by any current config option's own shape
+setenv_var TESTSUITE_ENABLE_SITECONFIG_VALIDVALLISTSTRINGIS 1
+set ans [list]
+lappend ans 42
+lappend ans $vers_reportre
+testouterr_cmd_re sh -V OK [join $ans \n]
+unsetenv_var TESTSUITE_ENABLE_SITECONFIG_VALIDVALLISTSTRINGIS
+
+# test the generic intvallist conversion path in getConf when no initproc is
+# set, not exercised by any current config option's own shape
+setenv_var TESTSUITE_ENABLE_SITECONFIG_INTVALLISTCONV 1
+set ans [list]
+lappend ans 20
+lappend ans $vers_reportre
+testouterr_cmd_re sh -V OK [join $ans \n]
+unsetenv_var TESTSUITE_ENABLE_SITECONFIG_INTVALLISTCONV
+
 # specific tests to improve formatErrStackTrace proc coverage
 setenv_var TESTSUITE_ENABLE_SITECONFIG_FORMATERRSTACKTRACE 1
 set ans [list]

--- a/testsuite/modules.00-init/120-siteconfig.exp
+++ b/testsuite/modules.00-init/120-siteconfig.exp
@@ -716,7 +716,7 @@ lappend ans {  "displaySeparatorLine $header $sgrkey $extra"}
 lappend ans {      (procedure "displayElementList" line 19)}
 lappend ans {      invoked from within}
 lappend ans {  "displayElementList $header $hsgrkey $hstyle $one_per_line $show_idx 1 $display_list $len_list $via_list"}
-lappend ans {      (procedure "reportModules" line 151)}
+lappend ans {      (procedure "reportModules" line 148)}
 lappend ans {      invoked from within}
 lappend ans {  "reportModules $args $dir mp $hstyle $show_mtime 0 $one_per_line $theader_cols hidden-loaded"}
 lappend ans {      (procedure "cmdModuleAvail" line 43)}

--- a/testsuite/modules.00-init/140-color.exp
+++ b/testsuite/modules.00-init/140-color.exp
@@ -183,6 +183,14 @@ if {$install_color eq {y}} {
     color_test_case {} 0 $sgr
 }
 
+#
+# ensure Modules-specific color config env var override and its internal
+# representation conversion get exercised regardless of quick test mode
+#
+setenv_var MODULES_COLOR always
+color_test_case {} 2 $sgr
+unsetenv_var MODULES_COLOR
+
 skip_if_quick_mode
 
 # environment variable or/and command-line switch override

--- a/testsuite/modules.20-locate/140-hide-full-path.exp
+++ b/testsuite/modules.20-locate/140-hide-full-path.exp
@@ -131,6 +131,7 @@ set tserr "$modlin Aliases $modlin
 tag/1.1.al -> tag/1.0
 
 $modlin Versions $modlin
+loc_edm1/default -> loc_edm1/1.0.1
 loc_fdv2/default -> loc_fdv2/1.2
 tag/1.1.sym -> tag/1.0"
 
@@ -168,6 +169,7 @@ set tserr "$modlin Aliases $modlin
 tag/1.1.al -> tag/1.0
 
 $modlin Versions $modlin
+loc_edm1/default -> loc_edm1/1.0.1
 loc_fdv2/default -> loc_fdv2/1.2
 tag/1.1.sym -> tag/1.0"
 

--- a/testsuite/modules.20-locate/171-multidefault.exp
+++ b/testsuite/modules.20-locate/171-multidefault.exp
@@ -1,0 +1,78 @@
+##############################################################################
+#   Modules Revision 3.0
+#   Providing a flexible user environment
+#
+#   File:		modules.20-locate/%M%
+#   Revision:		%I%
+#   First Edition:	2026/08/14
+#   Last Mod.:		%U%, %G%
+#
+#   Authors:		Xavier Delaruelle, xavier.delaruelle@cea.fr
+#
+#   Description:	Testuite testsequence
+#   Command:		load, display
+#   Modulefiles:	loc_edm1
+#   Sub-Command:
+#
+#   Comment:	%C{
+#			Check that a partial version query resolved through the
+#			extended_default mechanism, which ends up matching several
+#			available versions, correctly prefers the version
+#			explicitly set as 'default' over the highest matching one,
+#			whether the implicit_default option is enabled or disabled
+#		}C%
+#
+##############################################################################
+
+# skip tests if extended_default or implicit_default option could not be
+# overridden
+if {[is_config_locked extended_default] || [is_config_locked\
+    implicit_default]} {
+    send_user "\tskipping tests as extended_default or implicit_default\
+        could not be overridden\n"
+} else {
+
+# use a dedicated modulepath so this new fixture does not affect other tests
+# that enumerate the whole content of the default modulepath
+setenv_path_var MODULEPATH $modpath.4
+
+setenv_var MODULES_EXTENDED_DEFAULT 1
+
+set module "loc_edm1"
+set module_default "$module/1.0.1"
+set modulefile_default "$modpath.4/$module_default"
+set modulefilere_default "$modpathre.4/$module_default"
+
+#
+# loc_edm1 holds two sibling versions, 1.0.1 and 1.0.2, with 1.0.1 explicitly
+# set as 'default' through a '.version' file. A partial version query like
+# '1.0' matches both versions through extended_default: the resolution must
+# pick the explicitly defined default (1.0.1) rather than 1.0.2, which would
+# be selected if only the highest matching version was considered. This must
+# hold whether implicit_default is enabled or disabled
+#
+
+foreach implicitdefault {1 0} {
+
+setenv_var MODULES_IMPLICIT_DEFAULT $implicitdefault
+
+set ans [list]
+lappend ans [list set __MODULES_LMALTNAME\
+    $module_default&$module/default&$module]
+lappend ans [list set _LMFILES_ $modulefile_default]
+lappend ans [list set LOADEDMODULES $module_default]
+
+test_cmd "sh" "load $module/1.0" $ans
+
+testouterr_cmd_re "sh" "display $module/1.0" "OK"\
+    "$modlin\n$modulefilere_default:\n\nmodule-whatis\\s+$module_default\n$modlin"
+
+}
+
+#
+# Cleanup
+#
+
+reset_test_env
+
+}

--- a/testsuite/modules.50-cmds/700-module-warn.exp
+++ b/testsuite/modules.50-cmds/700-module-warn.exp
@@ -218,6 +218,12 @@ set line_num [expr {[cmpversion $tclsh_version 8.6] == -1 ? 2 : 29}]
 set tserr [escre [msg_moderr {Invalid option '--unk'} {module-warn --message text --unk warn/1<EXM>} $mp/warn/.modulerc $line_num {  }]]
 testouterr_cmd_re bash {load warn/1} $ans $tserr
 
+setenv_var TESTSUITE_WARN rc_bad5
+
+set line_num [expr {[cmpversion $tclsh_version 8.6] == -1 ? 2 : 32}]
+set tserr [escre [msg_moderr {Missing value for '--message' option} {module-warn --message<EXM>} $mp/warn/.modulerc $line_num {  }]]
+testouterr_cmd_re bash {load warn/1} $ans $tserr
+
 setenv_var TESTSUITE_WARN mf_bad1
 set line_num [expr {[cmpversion $tclsh_version 8.6] == -1 ? 4 : 17}]
 set tserr [escre [msg_load warn/1 [msg_moderr {No message specified in argument} {module-warn<EXM>} $mp/warn/1 $line_num]]]
@@ -236,6 +242,11 @@ testouterr_cmd_re bash {load warn/1} ERR $tserr
 setenv_var TESTSUITE_WARN mf_bad4
 set line_num [expr {[cmpversion $tclsh_version 8.6] == -1 ? 4 : 26}]
 set tserr [escre [msg_load warn/1 [msg_moderr {Invalid option '--unk'} {module-warn --message text --unk warn/1<EXM>} $mp/warn/1 $line_num]]]
+testouterr_cmd_re bash {load warn/1} ERR $tserr
+
+setenv_var TESTSUITE_WARN mf_bad5
+set line_num [expr {[cmpversion $tclsh_version 8.6] == -1 ? 4 : 29}]
+set tserr [escre [msg_load warn/1 [msg_moderr {Missing value for '--message' option} {module-warn --message<EXM>} $mp/warn/1 $line_num]]]
 testouterr_cmd_re bash {load warn/1} ERR $tserr
 
 

--- a/testsuite/modules.51-scan/033-scan_eval-spider.exp
+++ b/testsuite/modules.51-scan/033-scan_eval-spider.exp
@@ -190,7 +190,7 @@ scan/2.1{foo=val1,val2,val3}"
 testouterr_cmd sh {spider -t -o tag:variant:sym:alias scan} OK $tserr
 
 set tserr ".*
-Get modules: {foo/globalsym scan/globalsym foo/globalunk scan/globalunk} matching 'foo=val4' in ''
+Get modules: {(foo/globalsym|scan/globalsym|foo/globalunk|scan/globalunk) (foo/globalsym|scan/globalsym|foo/globalunk|scan/globalunk) (foo/globalsym|scan/globalsym|foo/globalunk|scan/globalunk) (foo/globalsym|scan/globalsym|foo/globalunk|scan/globalunk)} matching 'foo=val4' in ''
 .*
 Get modules: {((source|scan|foo).* )*(source|scan|foo).*} matching 'foo=val4' in '$mpre'
 scan/1.0{foo=val1,val2,val3,val4}\\\(globalsym:sym\\\)

--- a/testsuite/modules.51-scan/046-extra_spec-provide.exp
+++ b/testsuite/modules.51-scan/046-extra_spec-provide.exp
@@ -107,6 +107,14 @@ testouterr_cmd sh {avail -t provided-alias:foo} OK $tserr
 # info_extension tests
 #
 
+# info_extension is off by default, so a scanned "extensions" command
+# records a "provided-alias" element in addition to "provide"
+setenv_var TESTSUITE_PROVIDE extensions
+
+set tserr provide/1
+testouterr_cmd sh {avail -t provide provide:foo/1} OK $tserr
+testouterr_cmd sh {avail -t provide provided-alias:qux/1} OK $tserr
+
 setenv_var MODULES_INFO_EXTENSION 1
 
 setenv_var TESTSUITE_PROVIDE multiple

--- a/testsuite/modules.70-maint/120-autoinit.exp
+++ b/testsuite/modules.70-maint/120-autoinit.exp
@@ -101,9 +101,9 @@ set tserr_initrc1_exinstalled [msg_load null]
 
 set lminit_modrc_exinstalled "module use --append $install_modulepath:module load null"
 set lminit_modrc1_exinstalled "module use --append $install_modulepath:module load null"
-set lminit_modspath_modrc1_exinstalled "module use --append $install_modulepath:module use --append $install_prefix/test/modulefiles:module use --append $install_prefix/test/etc:module load null"
+set lminit_modspath_modrc1_exinstalled "module use --append $install_modulepath:module use --append $install_prefix/test/modulefiles:module use --append $install_prefix/test/etc:module use --append $install_prefix/test/absent:module load null"
 set lminit_initrc_exinstalled "module use --append {$modpath wspace}:module use --append $modpath.deps:module load --tag=auto-loaded m1:module load m3:module load {space yc/4}"
-set lminit_modspath_exinstalled "module use --append $install_modulepath:module use --append $install_prefix/test/modulefiles:module use --append $install_prefix/test/etc"
+set lminit_modspath_exinstalled "module use --append $install_modulepath:module use --append $install_prefix/test/modulefiles:module use --append $install_prefix/test/etc:module use --append $install_prefix/test/absent"
 
 
 # check if stderr terminal attachment state is forced
@@ -1281,7 +1281,7 @@ if {(!$insmodspath || $modspath_exinstalled) && (!$insmodrc || $modrc_exinstalle
                         lappend ans [list set MODULES_CMD $modulecmd_path]
                         lappend ans [list set MODULES_AUTO_HANDLING 0]
                         lappend ans [list set MODULES_ML 0]
-                        lappend ans [list set MODULEPATH "$install_modulepath:$install_prefix/test/modulefiles:$install_prefix/test/etc"]
+                        lappend ans [list set MODULEPATH "$install_modulepath:$install_prefix/test/modulefiles:$install_prefix/test/etc:$install_prefix/test/absent"]
                         lappend ans [list set __MODULES_LMINIT $lminit_modspath_modrc1_exinstalled]
                         lappend ans [list set MODULES_SET_SHELL_STARTUP 0]
                         lappend ans [list set MODULES_SHELLS_WITH_KSH_FPATH "sh:bash"]
@@ -1312,7 +1312,7 @@ if {(!$insmodspath || $modspath_exinstalled) && (!$insmodrc || $modrc_exinstalle
                             lappend ans [list set FPATH $install_initdir/ksh-functions]
                         }
                         lappend ans [list set __MODULES_LMINIT $lminit_modspath_modrc1_exinstalled]
-                        lappend ans [list set MODULEPATH "$install_modulepath:$install_prefix/test/modulefiles:$install_prefix/test/etc"]
+                        lappend ans [list set MODULEPATH "$install_modulepath:$install_prefix/test/modulefiles:$install_prefix/test/etc:$install_prefix/test/absent"]
                         if {$install_versioning eq "y"} {
                             lappend ans [list set MODULE_VERSION "(.*)"]
                         }
@@ -1345,7 +1345,7 @@ if {(!$insmodspath || $modspath_exinstalled) && (!$insmodrc || $modrc_exinstalle
                         lappend ans [list set FPATH $install_initdir/ksh-functions]
                     }
                     lappend ans [list set __MODULES_LMINIT $lminit_modspath_exinstalled]
-                    lappend ans [list set MODULEPATH "$install_modulepath:$install_prefix/test/modulefiles:$install_prefix/test/etc"]
+                    lappend ans [list set MODULEPATH "$install_modulepath:$install_prefix/test/modulefiles:$install_prefix/test/etc:$install_prefix/test/absent"]
                     if {$install_versioning eq "y"} {
                         lappend ans [list set MODULE_VERSION "(.*)"]
                     }
@@ -2140,7 +2140,7 @@ if {$insmodspath && $modspath_exinstalled && $modspath eq "$install_etcdir/modul
     lappend ans [list set MODULESHOME $moduleshome]
     lappend ans [list set LOADEDMODULES ""]
     lappend ans [list set __MODULES_LMINIT $lminit_modspath_exinstalled]
-    lappend ans [list set MODULEPATH "$install_modulepath:$install_prefix/test/modulefiles:$install_prefix/test/etc"]
+    lappend ans [list set MODULEPATH "$install_modulepath:$install_prefix/test/modulefiles:$install_prefix/test/etc:$install_prefix/test/absent"]
     if {$install_versioning eq "y"} {
         lappend ans [list set MODULE_VERSION "(.*)"]
     }

--- a/testsuite/modules.70-maint/270-adv_version_spec.exp
+++ b/testsuite/modules.70-maint/270-adv_version_spec.exp
@@ -157,6 +157,11 @@ testouterr_cmd_re sh {whatis extdfl@1.4.5} OK "$modlin $mpre $modlin
 \\s+extdfl/1.4.5: extdfl/1.4.5"
 testouterr_cmd sh {paths extdfl @1.4.5} [list [list text $mp/extdfl/1.4.5]] {}
 
+# a spec made of a variant-only element (no module name) must be correctly
+# flushed as a wildcard name query once a subsequent element bearing an
+# actual module name starts a new spec (nonamespec-allowed sub-commands only)
+testouterr_cmd sh {avail -t somevariant=val extdfl@1.4} OK "$mp:\nextdfl/1.4.5"
+
 # test various modulefile kind: alias, symver, virtual, directory hidden
 testouterr_cmd sh {avail -t extdfl3@1.00} OK "$mp:\nextdfl3/1.00(@)"
 testouterr_cmd sh {avail -t extdfl7 @3.0} OK "$mp:\nextdfl7/2.10(3.0)"

--- a/testsuite/modules.70-maint/274-adv_version_spec-autosym.exp
+++ b/testsuite/modules.70-maint/274-adv_version_spec-autosym.exp
@@ -416,6 +416,44 @@ unsetenv_loaded_module
 unsetenv_var __MODULES_LMALTNAME
 
 
+# autosymbol name matches an explicit symbolic version that is itself
+# targeted by a module-forbid command coupled to a module-hide --hard one:
+# the entry already found (in error) for this name short-circuits autosymbol
+# creation, yet resolution to the forbidden module is still attempted
+#
+# uses modulefiles.4 rather than modulefiles.2, so this fixture does not show
+# up in the other tests that enumerate modulefiles.2's entire content
+
+set mp_saved $mp
+set mp "$modpath.4"
+setenv_path_var MODULEPATH $mp
+
+testouterr_cmd sh {avail -t autosym10@default} OK $mp:\nautosym10/2
+testouterr_cmd sh {avail -t autosym10@latest} OK {}
+testouterr_cmd sh {avail -t autosym10/latest} OK {}
+set ans [list]
+lappend ans [list set __MODULES_LMALTNAME autosym10/2&as|autosym10/latest&as|autosym10/default]
+lappend ans [list set _LMFILES_ $mp/autosym10/2]
+lappend ans [list set LOADEDMODULES autosym10/2]
+testouterr_cmd sh {load autosym10} $ans {}
+testouterr_cmd sh {load autosym10/default} $ans {}
+testouterr_cmd sh {load autosym10@latest} ERR [err_accessdenied autosym10/latest]
+testouterr_cmd sh {load autosym10/latest} ERR [err_accessdenied autosym10/latest]
+testouterr_cmd sh {whatis autosym10@latest} ERR [err_accessdenied autosym10/latest]
+testouterr_cmd sh {is-loaded autosym10/default} ERR {}
+testouterr_cmd sh {is-loaded autosym10@latest} ERR {}
+setenv_loaded_module [list autosym10/2] [list $mp/autosym10/2]
+setenv_var __MODULES_LMALTNAME autosym10/2&as|autosym10/latest&as|autosym10/default
+testouterr_cmd sh {is-loaded autosym10/default} OK {}
+testouterr_cmd sh {is-loaded autosym10@latest} OK {}
+testouterr_cmd sh {list} OK "$cur_loaded\n 1) autosym10/2"
+unsetenv_loaded_module
+unsetenv_var __MODULES_LMALTNAME
+
+set mp $mp_saved
+setenv_path_var MODULEPATH $mp
+
+
 # use in requirements
 
 set ans [list]


### PR DESCRIPTION
Codecov (https://app.codecov.io/gh/envmodules/modules/tree/main/tcl) flagged 26 uncovered lines across `tcl/`. Working through them:

- 10 lines got new tests exercising genuine gaps (some via `siteconfig.tcl-1` global-state injection, matching the pattern the suite already uses for config-option-shape and on-the-fly-procedure-redefinition coverage, for branches no real caller can currently reach).
- 3 lines turned out to be genuine dead code, not test gaps — fixed:
  - `modfind.tcl.in`: an `elseif` in `getModules`' version-symbol collection that became unreachable the moment it was added in 2020 (a sibling commit on the same day had already made the `if` above it absorb the case unconditionally).
  - `report.tcl.in`: an existence guard in the module-listing proc that's been dead since 2019 (the variable it checks is unconditionally initialized earlier in the same proc).
  - `modfind.tcl.in`: an existence guard in `unsetModuleDependency`'s unmet-dependency cleanup — the two structures it checks are always written and cleared together, so the guard can never be false.
- 12 lines were flagged as bare closing braces of else-less `if` blocks. Those don't mean "block never entered" — Nagelfar/Codecov flag them when the *condition* has never evaluated false in any run. That reading changed the fix for several of them (forcing a skip path, not an entry path); details are in the individual commit messages.
- 1 line remains open: `modfind.tcl.in`'s dependency-cycle refresh (`setModuleDependency`) has a narrow theoretical path via `require_via` modulepath-swapping combined with a cycle that wasn't reachable through any load/unload/prereq sequence tried, and wasn't proven dead either. Left as-is.

No behavior changes except the 3 dead-code removals, each verified to be a no-op.
