### PR TITLE
ts: cover remaining tcl/ line-coverage gaps

### DIFF
--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -67,9 +67,10 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
+      # no token needed: public repo uses Codecov's tokenless upload via
+      # GitHub OIDC, which also works for pull requests coming from forks
+      # (base repo secrets are never exposed to fork-triggered PR runs)
       - uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
@@ -154,9 +155,10 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
+      # no token needed: public repo uses Codecov's tokenless upload via
+      # GitHub OIDC, which also works for pull requests coming from forks
+      # (base repo secrets are never exposed to fork-triggered PR runs)
       - uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
@@ -237,9 +239,10 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
+      # no token needed: public repo uses Codecov's tokenless upload via
+      # GitHub OIDC, which also works for pull requests coming from forks
+      # (base repo secrets are never exposed to fork-triggered PR runs)
       - uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
@@ -305,9 +308,10 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
+      # no token needed: public repo uses Codecov's tokenless upload via
+      # GitHub OIDC, which also works for pull requests coming from forks
+      # (base repo secrets are never exposed to fork-triggered PR runs)
       - uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
@@ -375,9 +379,10 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
+      # no token needed: public repo uses Codecov's tokenless upload via
+      # GitHub OIDC, which also works for pull requests coming from forks
+      # (base repo secrets are never exposed to fork-triggered PR runs)
       - uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
@@ -520,9 +525,10 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
+      # no token needed: public repo uses Codecov's tokenless upload via
+      # GitHub OIDC, which also works for pull requests coming from forks
+      # (base repo secrets are never exposed to fork-triggered PR runs)
       - uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v7
         if: failure()
         with:

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -62,9 +62,10 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
+      # no token needed: public repo uses Codecov's tokenless upload via
+      # GitHub OIDC, which also works for pull requests coming from forks
+      # (base repo secrets are never exposed to fork-triggered PR runs)
       - uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v7
         if: failure()
         with:

--- a/tcl/init.tcl.in
+++ b/tcl/init.tcl.in
@@ -730,9 +730,7 @@ proc initConfColor {envvar value validvallist intvallist} {
    }
 
    # convert value to its internal representation
-   if {[llength $intvallist]} {
-      set value [lindex $intvallist [lsearch -exact $validvallist $value]]
-   }
+   set value [lindex $intvallist [lsearch -exact $validvallist $value]]
 
    # disable color mode if no terminal attached except if 'always' asked
    if {$value != 0 && (![getState is_stderr_tty] || $value == 2)} {

--- a/testsuite/example/siteconfig.tcl-1
+++ b/testsuite/example/siteconfig.tcl-1
@@ -381,6 +381,21 @@ foo
     report [formatErrStackTrace $errmsg foo]
 }
 
+# specific test to improve formatErrStackTrace proc coverage: the topmost
+# stack frame is itself an 'eval [...]' wrapper (as modulefile content is
+# evaluated via 'eval [getModuleContent $::ModulesCurrentModulefile]'), which
+# requires extracting the inner command from the second word of that frame
+if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_FORMATERRSTACKTRACE_EVAL)]} {
+    set errmsg {error message
+    while executing
+"eval [getModuleContent $::ModulesCurrentModulefile]"
+    invoked from within
+"eval [getModuleContent $::ModulesCurrentModulefile]"
+    (file "foo")}
+
+    report [formatErrStackTrace $errmsg foo]
+}
+
 # produce an unknown error in a modulecmd.tcl procedure during a modulefile evaluation
 if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_UNKINTERRDURINGMODEVAL)]} {
     proc getModshareVarName {var} {

--- a/testsuite/modules.00-init/120-siteconfig.exp
+++ b/testsuite/modules.00-init/120-siteconfig.exp
@@ -651,6 +651,16 @@ lappend ans $vers_reportre
 testouterr_cmd_re sh -V OK [join $ans \n]
 unsetenv_var TESTSUITE_ENABLE_SITECONFIG_FORMATERRSTACKTRACE
 
+# specific test to improve formatErrStackTrace proc coverage: topmost stack
+# frame is itself an 'eval [...]' wrapper
+setenv_var TESTSUITE_ENABLE_SITECONFIG_FORMATERRSTACKTRACE_EVAL 1
+set ans [list]
+lappend ans {}
+lappend ans {    \(file "foo"\)}
+lappend ans $vers_reportre
+testouterr_cmd_re sh -V OK [join $ans \n]
+unsetenv_var TESTSUITE_ENABLE_SITECONFIG_FORMATERRSTACKTRACE_EVAL
+
 # produce an unknown error in a modulecmd.tcl procedure during a modulefile evaluation
 setenv_var TESTSUITE_ENABLE_SITECONFIG_UNKINTERRDURINGMODEVAL 1
 set ans [msg_moderr {invalid command name "foo"} {foo} $modpath/setenv/1.0 30 {} {} {} {    (procedure "getModshareVarName" line 2)

--- a/testsuite/modules.00-init/140-color.exp
+++ b/testsuite/modules.00-init/140-color.exp
@@ -191,6 +191,15 @@ setenv_var MODULES_COLOR always
 color_test_case {} 2 $sgr
 unsetenv_var MODULES_COLOR
 
+# an invalid Modules-specific color config env var override is ignored
+setenv_var MODULES_COLOR foo
+if {$install_color eq {y}} {
+    color_test_case {} 1 $sgr
+} else {
+    color_test_case {} 0 $sgr
+}
+unsetenv_var MODULES_COLOR
+
 skip_if_quick_mode
 
 # environment variable or/and command-line switch override

--- a/testsuite/modules.70-maint/120-autoinit.exp
+++ b/testsuite/modules.70-maint/120-autoinit.exp
@@ -2197,6 +2197,61 @@ if {$insmodspath && $modspath_exinstalled && $modspath eq "$install_etcdir/modul
 }
 
 
+# test a modulespath file present but yielding no additional path entries
+# (only comments) correctly adds no extra 'module use --append' and behaves
+# just as if no modulespath file were installed at all
+if {$insmodspath && $modspath_exinstalled && $modspath eq "$install_etcdir/modulespath"\
+    && !$modrc_exinstalled && !$modrc1_exinstalled && !$initrc_exinstalled} {
+    # temporarily replace etc/modulespath with a comments-only variant
+    set fid [open $modspath r]
+    set origmodspathdata [read $fid]
+    close $fid
+    set fid [open $env(TESTSUITEDIR)/example/modulespath-empty r]
+    set emptymodspathdata [read $fid]
+    close $fid
+    set fid [open $modspath w]
+    puts -nonewline $fid $emptymodspathdata
+    close $fid
+
+    set ans [list]
+    lappend ans [list [set "func_sh"]]
+    if {$install_versioning eq "y"} {
+        lappend ans [list set MODULE_VERSION_STACK "(.*)"]
+    }
+    lappend ans [list set MODULES_CMD $modulecmd_path]
+    if {$change_manpath} {
+        if {$extra_sysmanpath} {
+            lappend ans [list set __MODULES_SHARE_MANPATH :1]
+        }
+        lappend ans [list set MANPATH $updatedmanpath]
+    }
+    if {$change_path} {
+        lappend ans [list set PATH $updatedpath]
+    }
+    if {$install_setshellstartup eq {y}} {
+        lappend ans [list set ENV $install_initdir/profile.sh]
+    }
+    lappend ans [list unset __MODULES_AUTOINIT_INPROGRESS]
+    if {$install_setshellstartup eq {y}} {
+        lappend ans [list set BASH_ENV $install_initdir/bash]
+    }
+    lappend ans [list set MODULESHOME $moduleshome]
+    lappend ans [list set LOADEDMODULES ""]
+    lappend ans [list set __MODULES_LMINIT ""]
+    lappend ans [list set MODULEPATH ""]
+    if {$install_versioning eq "y"} {
+        lappend ans [list set MODULE_VERSION "(.*)"]
+    }
+
+    testouterr_cmd_re sh autoinit $ans {}
+
+    # restore original etc/modulespath content
+    set fid [open $modspath w]
+    puts -nonewline $fid $origmodspathdata
+    close $fid
+}
+
+
 # ensure ml is set disabled as if modrc1 initrc were previously evaluated
 # since modulepath and modules are loaded, initrc will not be evaluated by autoinit
 if {$modrc1_exinstalled} {


### PR DESCRIPTION
- Cover the invalid-`MODULES_COLOR` env var override branch, and remove an unreachable `intvallist` guard found alongside it in the color config init proc.
- Cover the `eval [...]`-wrapped topmost stack frame case in the error stack trace formatting proc, via a corrected synthetic siteconfig test (the existing one used an unquoted frame that never matched that shape).
- Cover the comments-only modulespath init file case (present but yielding no path entries), distinct from the file being absent or containing real paths.
- Drop the now-unnecessary `CODECOV_TOKEN` from the coverage upload steps, since fork-triggered PR runs never receive base repo secrets and the token was silently failing the upload for those.