### PR TITLE
gh: turn on Codecov identity-token upload path

### DIFF
--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   tcl86-nolibtclenvmodules:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
     env:
       CONFIGURE_OPTS: |
         --with-tclsh=tclsh8.6
@@ -67,10 +69,12 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
-      # no token needed: public repo uses Codecov's tokenless upload via
-      # GitHub OIDC, which also works for pull requests coming from forks
-      # (base repo secrets are never exposed to fork-triggered PR runs)
+      # no token needed: id-token permission above lets Codecov verify
+      # this public repo via GitHub OIDC, which also works for pull
+      # requests from forks (base repo secrets are never exposed there)
       - uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
@@ -82,6 +86,8 @@ jobs:
 
   tcl85-nolibtclenvmodules:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
     env:
       CONFIGURE_OPTS: |
         --with-tclsh=tclsh8.5
@@ -155,10 +161,12 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
-      # no token needed: public repo uses Codecov's tokenless upload via
-      # GitHub OIDC, which also works for pull requests coming from forks
-      # (base repo secrets are never exposed to fork-triggered PR runs)
+      # no token needed: id-token permission above lets Codecov verify
+      # this public repo via GitHub OIDC, which also works for pull
+      # requests from forks (base repo secrets are never exposed there)
       - uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
@@ -170,6 +178,8 @@ jobs:
 
   tcl85-2:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
     env:
       CONFIGURE_OPTS: |
         --with-tclsh=tclsh8.5
@@ -239,10 +249,12 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
-      # no token needed: public repo uses Codecov's tokenless upload via
-      # GitHub OIDC, which also works for pull requests coming from forks
-      # (base repo secrets are never exposed to fork-triggered PR runs)
+      # no token needed: id-token permission above lets Codecov verify
+      # this public repo via GitHub OIDC, which also works for pull
+      # requests from forks (base repo secrets are never exposed there)
       - uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
@@ -254,6 +266,8 @@ jobs:
 
   tcl86:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
     env:
       CONFIGURE_OPTS: |
         --with-tclsh=tclsh8.6
@@ -308,10 +322,12 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
-      # no token needed: public repo uses Codecov's tokenless upload via
-      # GitHub OIDC, which also works for pull requests coming from forks
-      # (base repo secrets are never exposed to fork-triggered PR runs)
+      # no token needed: id-token permission above lets Codecov verify
+      # this public repo via GitHub OIDC, which also works for pull
+      # requests from forks (base repo secrets are never exposed there)
       - uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
@@ -323,6 +339,8 @@ jobs:
 
   tcl85:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
     env:
       CONFIGURE_OPTS: |
         --with-tclsh=tclsh8.5
@@ -379,10 +397,12 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
-      # no token needed: public repo uses Codecov's tokenless upload via
-      # GitHub OIDC, which also works for pull requests coming from forks
-      # (base repo secrets are never exposed to fork-triggered PR runs)
+      # no token needed: id-token permission above lets Codecov verify
+      # this public repo via GitHub OIDC, which also works for pull
+      # requests from forks (base repo secrets are never exposed there)
       - uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
@@ -475,6 +495,8 @@ jobs:
 
   tcl90:
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
     env:
       CONFIGURE_OPTS: |
         --with-tclsh=tclsh9.0
@@ -525,10 +547,12 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
-      # no token needed: public repo uses Codecov's tokenless upload via
-      # GitHub OIDC, which also works for pull requests coming from forks
-      # (base repo secrets are never exposed to fork-triggered PR runs)
+      # no token needed: id-token permission above lets Codecov verify
+      # this public repo via GitHub OIDC, which also works for pull
+      # requests from forks (base repo secrets are never exposed there)
       - uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
       - uses: actions/upload-artifact@v7
         if: failure()
         with:

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   macos:
     runs-on: macos-15
+    permissions:
+      id-token: write
     env:
       CONFIGURE_OPTS: |
         --prefix=/tmp/modules
@@ -62,10 +64,12 @@ jobs:
       - name: Uninstall Modules
         run: |
           make uninstall
-      # no token needed: public repo uses Codecov's tokenless upload via
-      # GitHub OIDC, which also works for pull requests coming from forks
-      # (base repo secrets are never exposed to fork-triggered PR runs)
+      # no token needed: id-token permission above lets Codecov verify
+      # this public repo via GitHub OIDC, which also works for pull
+      # requests from forks (base repo secrets are never exposed there)
       - uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
       - uses: actions/upload-artifact@v7
         if: failure()
         with:


### PR DESCRIPTION
## Summary
- Codecov's no-token upload verifies a run through a GitHub Actions identity token, but `codecov-action` only requests it when its own opt-in input is enabled, and the job needs `id-token: write` to obtain the token at all. Neither was set, so uploads failed with `Token required - not valid tokenless upload` on every run (confirmed by rerunning the last main commit and PR #673).
- Grants `id-token: write` and turns on that opt-in input on the jobs that upload coverage in `linux_tests.yaml` and `macos_tests.yaml`.