### PR TITLE
Make error report inhibition safe to nest

### DIFF
--- a/.hunspell.en.dic
+++ b/.hunspell.en.dic
@@ -423,6 +423,7 @@ envvar
 envvars
 eol
 eq
+errreport
 etcdic
 etcdir
 eu
@@ -509,6 +510,7 @@ icdiff
 idx
 incompat
 indepth
+inhibitErrorReport
 init
 initStateClockSeconds
 initStateUsergroups
@@ -908,6 +910,7 @@ uname
 uncomplete
 undef
 unhide
+uninhibitErrorReport
 unmetDepHash
 unix
 unixtime

--- a/tcl/mfcmd.tcl
+++ b/tcl/mfcmd.tcl
@@ -1355,12 +1355,8 @@ proc is-avail {args} {
    set args [parseModuleSpecification 0 0 0 0 {*}$args]
    set ret 0
 
-   # disable error reporting to avoid modulefile errors
-   # to pollute result. Only if not already inhibited
-   set alreadyinhibit [getState inhibit_errreport]
-   if {!$alreadyinhibit} {
-      inhibitErrorReport
-   }
+   # disable error reporting to avoid modulefile errors to pollute result
+   inhibitErrorReport
 
    foreach mod $args {
       lassign [getPathToModule $mod] modfile modname modnamevr
@@ -1370,10 +1366,7 @@ proc is-avail {args} {
       }
    }
 
-   # re-enable only is it was disabled from this procedure
-   if {!$alreadyinhibit} {
-      setState inhibit_errreport 0
-   }
+   uninhibitErrorReport
    return $ret
 }
 

--- a/tcl/modscan.tcl
+++ b/tcl/modscan.tcl
@@ -418,10 +418,7 @@ proc scanExtraMatchSearch {modpath mod res_arrname} {
 
    # disable error reporting to avoid modulefile errors (not coping with
    # scan evaluation for instance) to pollute result
-   set alreadyinhibit [getState inhibit_errreport]
-   if {!$alreadyinhibit} {
-      inhibitErrorReport
-   }
+   inhibitErrorReport
    # evaluate all modules found in scan mode to gather content information
    lappendState mode scan
 
@@ -440,10 +437,7 @@ proc scanExtraMatchSearch {modpath mod res_arrname} {
    }
 
    lpopState mode
-   # re-enable error report only is it was disabled from this procedure
-   if {!$alreadyinhibit} {
-      setState inhibit_errreport 0
-   }
+   uninhibitErrorReport
 }
 
 # perform extra match search on currently being built module search result

--- a/tcl/report.tcl.in
+++ b/tcl/report.tcl.in
@@ -672,10 +672,20 @@ proc reportName {} {
    report Modules
 }
 
-# disable error reporting (non-critical report only) unless debug enabled
+# disable error reporting (non-critical report only) unless debug enabled.
+# keep track of inhibition depth to cope with nested calls
 proc inhibitErrorReport {} {
    if {![isVerbosityLevel trace]} {
-      setState inhibit_errreport 1
+      setState inhibit_errreport [expr {[getState inhibit_errreport] + 1}]
+   }
+}
+
+# withdraw an error report inhibition demand (depth stays null if demand
+# was made under trace verbosity where inhibition is disabled)
+proc uninhibitErrorReport {} {
+   set inhibit_depth [getState inhibit_errreport]
+   if {$inhibit_depth > 0} {
+      setState inhibit_errreport [expr {$inhibit_depth - 1}]
    }
 }
 

--- a/tcl/subcmd.tcl.in
+++ b/tcl/subcmd.tcl.in
@@ -413,7 +413,7 @@ proc cmdModuleSearch {args} {
    }
    lpopState mode
 
-   setState inhibit_errreport 0
+   uninhibitErrorReport
 
    # report errors if a modulefile was searched but not found
    if {{wild} ni $searchmod && !$foundmod} {
@@ -1853,7 +1853,7 @@ proc cmdModuleAliases {} {
       getModules $dir {} 0 {}
    }
 
-   setState inhibit_errreport 0
+   uninhibitErrorReport
 
    set display_list {}
    foreach name [lsort -dictionary [array names ::g_moduleAlias]] {
@@ -1945,7 +1945,7 @@ proc cmdModuleAvail {show_oneperline show_mtime show_filter search_filter\
       displayKey
    }
 
-   setState inhibit_errreport 0
+   uninhibitErrorReport
 }
 
 proc runModuleUse {cmd mode pos args} {
@@ -2875,7 +2875,7 @@ proc cmdModuleLint {args} {
             }
          }
       }
-      setState inhibit_errreport 0
+      uninhibitErrorReport
    } else {
       foreach mod $args {
          lassign [getPathToModule $mod] modfile modname modnamevr
@@ -3159,7 +3159,7 @@ proc cmdModuleSpider {show_oneperline show_mtime show_filter search_filter\
    }
    unsetConf advanced_version_spec
    defineParseModuleSpecificationProc [getConf advanced_version_spec]
-   setState inhibit_errreport 0
+   uninhibitErrorReport
    reportTrace $modpath_list {Collect modulepaths}
 
    # perform an avail on all collected modulepaths


### PR DESCRIPTION
Error report inhibition is re-enabled by resetting `inhibit_errreport` state to 0, which would clobber the inhibition demand of a calling procedure. `scanExtraMatchSearch` and `is-avail` guard against this with their own save/restore of current state, but the five sub-command procedures using `inhibitErrorReport` do not.

Track inhibition depth in `inhibit_errreport` state and add the `uninhibitErrorReport` procedure to withdraw one demand. All sites now use the same symmetric call pair, safe whatever the nesting context. The unconditional reset in the top-level error handler is kept as the safety net.

No behavior change: broken modulerc files stay silently ignored on `avail`/`aliases`/`whatis`/`spider`/`lint` and are still reported on `load`.