### PR TITLE
Document commit, PR and testsuite conventions for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,11 @@ script/mb profile
 cd doc && make html   # requires Sphinx >= 1.0; output in doc/_build/html
 ```
 
+In `.rst` files, make a section title's underline exactly as long as the
+title text — no more, no less. Sphinx silently accepts a longer underline,
+so a length mismatch has to be checked deliberately whenever a title is
+added or its text edited.
+
 ## Repository layout
 
 - `tcl/` — Tcl source, split by concern; concatenated into `modulecmd.tcl`
@@ -177,11 +182,30 @@ cd doc && make html   # requires Sphinx >= 1.0; output in doc/_build/html
   git `user.name`/`user.email` — use `git commit -s`.
 - Patches (bug fix or feature) should include tests, and the test should be
   shown to fail without the patch.
+- A commit body describes the change and why it is needed — never the
+  investigation or verification steps taken to produce it ("Verified
+  with `<command>`", "Confirmed via git archaeology"). If a verification
+  detail is essential to justify the change, state it as a plain
+  declarative fact about the change itself.
+- Squash small follow-up commits that merely refine a change introduced
+  earlier on the same branch (typo fix, forgotten hunk, reworded sentence)
+  into the commit introducing that change, so each commit in the series
+  stands as a coherent change. Only rewrite commits not pushed yet.
 - The project follows the Linux kernel's policy on AI coding assistants (see
   "AI coding assistants" in `CONTRIBUTING.rst`): never add a
   `Signed-off-by:` trailer on behalf of the AI — only the human committer
   signs off — and disclose AI involvement with an `Assisted-by:` trailer,
   e.g. `Assisted-by: Claude:claude-sonnet-5`.
+
+## Pull request descriptions
+
+- Start the body directly with the prose or bullet list describing the
+  change — no "Summary" or any other heading, no test-plan section, no
+  "Generated with ..." tool attribution line.
+- Do not hard-wrap the body to a column width — GitHub renders it as
+  Markdown and wraps paragraphs itself, so manual line breaks only produce
+  ragged text. The 72-column wrapping convention applies to commit
+  messages only.
 
 ## Updating NEWS.rst
 

--- a/testsuite/modules.50-cmds/560-siteconfig-interp.exp
+++ b/testsuite/modules.50-cmds/560-siteconfig-interp.exp
@@ -29,6 +29,24 @@ setenv_path_var MODULEPATH $mp
 
 
 # check expected siteconfig file is installed
+#
+# This testfile silently self-skips in a plain development checkout: it
+# requires testsuite/example/siteconfig.tcl-1 installed as
+# <etcdir>/siteconfig.tcl plus TESTSUITE_ENABLE_SITECONFIG=1 exported. The
+# primary siteconfig location has no environment override: it is the etcdir
+# baked into modulecmd-test.tcl at ./configure time (/usr/local/Modules/etc
+# by default, not writable without root). CI sets this up with a real 'make
+# install-testsiteconfig-1' (see .github/workflows/linux_tests.yaml).
+#
+# To exercise these tests locally without touching the system:
+#   1. ./configure --etcdir=<scratch>/etc
+#   2. force a full rebuild, as make does not regenerate the built files
+#      after a configure change: rm -f modulecmd.tcl modulecmd-test.tcl
+#      tcl/{init,cache,coll,envmngt,interp,main,modfind,report,subcmd}.tcl
+#      then make modulecmd.tcl modulecmd-test.tcl
+#   3. cp testsuite/example/siteconfig.tcl-1 <scratch>/etc/siteconfig.tcl
+#   4. TESTSUITE_ENABLE_SITECONFIG=1 script/mt 50/560
+#   5. restore with a plain ./configure and the same forced rebuild
 set is_stderr_tty [siteconfig_isStderrTty]
 if {$is_stderr_tty} {
 


### PR DESCRIPTION
- Add to AGENTS.md conventions so far only passed along as review feedback: commit bodies describe the change and its rationale rather than the investigation or verification steps behind it, small follow-up commits refining an earlier change on the same branch get squashed into it, pull request descriptions start directly with the change summary without boilerplate headings or hard-wrapping, and rst section title underlines must exactly match their title length since Sphinx does not report longer underlines.
- Document in 560-siteconfig-interp.exp why this testfile silently self-skips in a plain development checkout and how to set up a scratch etcdir to exercise its tests locally without root.