### PR TITLE
Refresh built scripts when configure updates Makefile.inc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -535,6 +535,15 @@ DIST_WIN_PREFIX := $(DIST_PREFIX)-win
 # avoid shared definitions to be rebuilt by make
 Makefile.inc: ;
 
+# refresh files embedding shared definitions when ./configure updates them
+# (tcl scripts and their assemblies follow through their version.inc
+# prerequisite)
+version.inc share/rpm/environment-modules.spec script/add.modules \
+	script/gitlog2changelog.py script/modulecmd \
+	testsuite/example/.modulespath testsuite/example/modulespath-wild \
+	testsuite/example/modulerc testsuite/example/initrc-1 \
+	testsuite/example/initrc: Makefile.inc
+
 version.inc: version.inc.in $(GIT_REFRESH_PREREQ)
 	$(translate-in-script)
 

--- a/init/Makefile
+++ b/init/Makefile
@@ -203,7 +203,11 @@ endef
 # avoid shared definitions to be rebuilt by make
 ../Makefile.inc: ;
 
-%: %.in
+# refresh files embedding shared definitions when ../configure updates them
+initrc tcsh profile.sh $(EXAMPLE_MODFILES_SRCDIR)/modules \
+	$(EXAMPLE_MODFILES_SRCDIR)/version: ../Makefile.inc
+
+%: %.in ../Makefile.inc
 	$(translate-in-script)
 
 # workaround '\\\n' issue on Linux with Make 3.81


### PR DESCRIPTION
- Files generated from a .in source only depended on this source, so after re-running ./configure with different installation paths a plain make silently kept scripts embedding the old prefix, breaking make install and the install testsuite until every generated file was manually removed.
- Declare Makefile.inc, which configure rewrites on each run, as a prerequisite of the translate-in-script generation rules in Makefile and init/Makefile. tcl scripts, modulecmd.tcl and modulecmd-test.tcl refresh through their existing version.inc prerequisite.
- A configure re-run with identical arguments now also triggers a regeneration pass on the next make, as Makefile.inc's timestamp always moves: rebuild cost is small and this could be made content-sensitive in configure if deemed worth it.