### PR TITLE
Cover code paths left uncovered by modulepath-ignore introduction

### DIFF
--- a/tcl/cache.tcl.in
+++ b/tcl/cache.tcl.in
@@ -107,7 +107,6 @@ proc formatModuleCacheContent {modpath} {
    # patterns they may define: silence their evaluation errors like during
    # an avail-like walk (their bare content is recorded whether their code
    # is correct or not)
-   set alreadyinhibit [getState inhibit_errreport]
    inhibitErrorReport
 
    # collect files from modulepath directory
@@ -116,10 +115,7 @@ proc formatModuleCacheContent {modpath} {
    # collect files and dirs from modulepath directory with limited access
    array set limited_list [getLimitedAccessesInDirectory $modpath]
 
-   # re-enable error report if it was enabled prior collection
-   if {!$alreadyinhibit} {
-      setState inhibit_errreport 0
-   }
+   uninhibitErrorReport
 
    # concatenate element found and those with limited access as the second
    # kind may not be part of found list

--- a/testsuite/modules.20-locate/180-modulepath-ignore.exp
+++ b/testsuite/modules.20-locate/180-modulepath-ignore.exp
@@ -157,19 +157,21 @@ file delete -force $userhome
 
 # double asterisk (leading, middle and mid-segment), character range
 # (regular and negated), single character, escaped characters, leading
-# slash anchor and unclosed character range patterns, defined over several
-# modulepath-ignore calls in same rc file
+# slash anchor, unclosed character range, trailing backslash (matched
+# literally, so 'esc\' pattern does not match 'esc' file) and void (slash
+# or negation character only, matching nothing) patterns, defined over
+# several modulepath-ignore calls in same rc file
 set mp4 $env(HOME)/mpign4
 file mkdir $mp4/app $mp4/lib/x $mp4/sub/doc $mp4/qux $mp4/quax $mp4/a/x/y\
     $mp4/mx
 set fid [open $mp4/.modulerc w]
 puts $fid "#%Module\nmodulepath-ignore **/doc lib/** {app/\[13\]*}\
     {\\!bang} qu?x\nmodulepath-ignore /root1* a/**/b {e\[!0-9\]f} m**n\
-    {br\[ack} {sp\\*t}"
+    {br\[ack} {sp\\*t}\nmodulepath-ignore / ! esc\\\\"
 close $fid
 foreach f [list app/1.0 app/2.0 app/3.0 lib/x/1.0 sub/doc/1.0 sub/1.0\
     qux/1.0 quax/1.0 !bang root1.0 sub/root1.5 a/b a/x/b a/x/y/b a/c exf\
-    e5f mooon mx/n {br[ack} {sp*t} spot] {
+    e5f mooon mx/n {br[ack} {sp*t} spot esc] {
     set fid [open $mp4/$f w]
     puts $fid $mfcontent
     close $fid
@@ -178,6 +180,7 @@ setenv_path_var MODULEPATH $mp4
 set tserr "a/c
 app/2.0
 e5f
+esc
 mx/n
 qux/1.0
 spot

--- a/testsuite/modules.30-cache/043-cache-use-limited-access.exp
+++ b/testsuite/modules.30-cache/043-cache-use-limited-access.exp
@@ -152,6 +152,17 @@ lappend ans_load1 [list set _LMFILES_ $mp1/bar/1.0]
 lappend ans_load1 [list set LOADEDMODULES bar/1.0]
 testouterr_cmd sh {load bar} $ans_load1 {}
 
+# load two module specifications of same root in a single command: module
+# search of second specification walks down again the limited access
+# elements from cache and finds the 'bar/.version' rc file already
+# evaluated during the module search of first specification
+set ans_load1b [list]
+lappend ans_load1b [list set __MODULES_LMALTNAME\
+    bar/1.0&bar/default&bar:bar/2.0&as|bar/latest]
+lappend ans_load1b [list set _LMFILES_ $mp1/bar/1.0:$mp1/bar/2.0]
+lappend ans_load1b [list set LOADEDMODULES bar/1.0:bar/2.0]
+testouterr_cmd sh {load bar bar/2.0} $ans_load1b {}
+
 set tserr_load2 "$err_magic'$mp1/foo/.modulerc'\n$err_contact
 $err_magic'$mp1/foo/1.0'\n$err_contact"
 testouterr_cmd sh {load foo/1.0} ERR $tserr_load2


### PR DESCRIPTION
Codecov reported 5 new uncovered lines after PR #682 was merged. This change covers them:

- `180-modulepath-ignore.exp`: exercise ignore patterns compiling to a void matcher (slash or negation character only) and a pattern with a trailing backslash, which is matched literally.
- `043-cache-use-limited-access.exp`: load two module specifications of same root in a single command, so the second module search walks down again the limited access elements from cache and finds the `bar/.version` rc file already evaluated.
- `formatModuleCacheContent` is converted to the `inhibitErrorReport`/`uninhibitErrorReport` pair introduced by 4d4c0dee, which it was left out of. Its state restore guard could never take the already-inhibited branch, as `cachebuild` only runs from top-level context: this unreachable branch is removed rather than tested.