### PR TITLE
Update tcl91 CI job to Tcl 9.1b0 and fail testsuite fast on modulecmd crash

### DIFF
--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -436,9 +436,9 @@ jobs:
           # libtclenvmodules build requirements
           sudo apt-get install -y gcc autoconf
           # manually install tcl9.1
-          curl -L --output tcl9.1a1-src.tar.gz http://downloads.sourceforge.net/tcl/tcl9.1a1-src.tar.gz
-          tar xfz tcl9.1a1-src.tar.gz
-          cd tcl9.1a1/unix
+          curl -L --output tcl9.1b0-src.tar.gz http://downloads.sourceforge.net/tcl/tcl9.1b0-src.tar.gz
+          tar xfz tcl9.1b0-src.tar.gz
+          cd tcl9.1b0/unix
           ./configure
           make -j
           sudo make install

--- a/testsuite/config/unix.exp
+++ b/testsuite/config/unix.exp
@@ -29,6 +29,16 @@
 # Tcl>=8.6): use channel pipe instead of saving these outputs in file
 if {[lindex [lsort -dictionary [list 8.6 [info tclversion]]] 1] eq [info tclversion]} {
 
+# catch background errors, like a modulecmd process killed by a signal that
+# makes readpipe raise an uncaught CHILDKILLED error from its event handler.
+# without this catching procedure defined, such an error leaves the endpipe
+# variable unset and the vwait call in modulecmd_xxx_ hangs forever
+proc bgerror {msg} {
+    send_user "ERROR: background error caught: $msg\n"
+    # release ongoing command wait to make related test fail right away
+    set ::endpipe error
+}
+
 proc readpipe {p1 p2 varname {exit_varname {}}} {
     append ::$varname [read $p1]
     if {[eof $p1]} {


### PR DESCRIPTION
Update the tcl91 CI job to build Tcl 9.1b0, which fixes the interpreter panic raised by 9.1a1 when the init.tcl script found in the `TCL_LIBRARY` environment variable fails to evaluate.

Also define a `bgerror` procedure in the testsuite configuration: when a spawned `modulecmd` process dies from a signal, closing its output channel raises a `CHILDKILLED` error that escapes the `readpipe` event handler as a background error. Without a `bgerror` procedure defined under `runtest`, the `endpipe` variable is left unset and the `vwait` call hangs forever, freezing the testsuite run until the CI job 6-hour timeout — as observed while debugging the tcl91 job hang on PR #689. With this procedure, such a crash is reported and the related test fails right away.